### PR TITLE
Only Clear Bank Journal if in absolute violation of company.

### DIFF
--- a/mcfix_account/models/account_bank_statement.py
+++ b/mcfix_account/models/account_bank_statement.py
@@ -23,7 +23,8 @@ class AccountBankStatement(models.Model):
 
     @api.onchange('company_id')
     def onchange_company_id(self):
-        self.journal_id = False
+        if self.company_in and self.journal_id.company_id != self.company_id:
+            self.journal_id = False
 
     def reconciliation_widget_preprocess(self):
         # This is the same code as the original method except for the fact


### PR DESCRIPTION
When the default comes up, if it calls onchange (depending what was
there) - which clears the default journal, and the journal type, meaning
the journal is not even selectable any more by domain.