### PR TITLE
[FIX 10.0] readonly company on account.move.line

### DIFF
--- a/mcfix_account/models/account_move.py
+++ b/mcfix_account/models/account_move.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from odoo import api, models, _
+from odoo import api, models, fields, _
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -100,6 +100,12 @@ class AccountMove(models.Model):
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
+
+    # It is non-sensical for account_move_lines to be
+    # have a write access to company_id on account.account.
+    # It causes unnecessary write calls to account.account
+    # and constraint validations.
+    company_id = fields.Many2one(readonly=True)
 
     @api.multi
     @api.depends('company_id')


### PR DESCRIPTION
Account move line link to company_id (related from account.account)
is not readonly in the base.  Some writes are causing an unnecessary
write to account.account on company_id (even though company_id is
not changing), which causes the constraint validation - which is
quite resource hungry given the large number of searches.
Besides being an unnecessary overhead, it fails when this module
has been installed on an existing database and there is history
that was not aligned.